### PR TITLE
Support background-images

### DIFF
--- a/src/__tests__/index.tsx
+++ b/src/__tests__/index.tsx
@@ -24,7 +24,7 @@ describe("Background Decorator", () => {
     const SpiedChannel = new EventEmitter();
     const backgroundDecorator = shallow(<BackgroundDecorator story={testStory} channel={SpiedChannel} />);
 
-    expect(backgroundDecorator.html().match(/background-color:transparent/gmi).length).toBe(1);
+    expect(backgroundDecorator.html().match(/background:transparent/gmi).length).toBe(1);
   });
 
   it("should set internal state when background event called", () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -56,7 +56,7 @@ export class BackgroundDecorator extends React.Component<any, any> {
 
   render() {
     const styles = style.wrapper;
-    styles.backgroundColor = this.state.background;
+    styles.background = this.state.background;
     return <div style={assign({}, styles)}>{this.story}</div>;
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,7 @@ const style = {
     transition: "background 0.25s ease-in-out",
     backgroundPosition: "center",
     backgroundSize: "cover",
-    backgroundColor: "transparent",
+    background: "transparent",
   },
 };
 


### PR DESCRIPTION
Removed the specificity of `backgroundColor` for a more inclusive `background`.

This allows the developer to specify both colors _and_ background images, including background gradients.

_Example:_
```
.addDecorator(backgrounds([
	{name: 'default', value: '#000000'},
	{name: 'image', value: 'gray url("http://lorempixel.com/720/480/") no-repeat center/cover'}
]));
```