### PR TITLE
fix: remove background fix position

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,6 @@ import assign = require("object-assign"); // tslint:disable-line
 
 const style = {
   wrapper: {
-    position: "fixed",
     top: 0,
     bottom: 0,
     right: 0,


### PR DESCRIPTION
Wrapper with fixed position will prevent the component area of storybook from scrolling down. 